### PR TITLE
Implement Altcha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ psycopg2==2.8.6
 unidecode==1.2.0
 #django-crispy-forms==1.10.0
 
+django-altcha
+
 # Monitoring requirements
 -i https://testpypi.python.org/pypi protobix

--- a/settings.py
+++ b/settings.py
@@ -61,7 +61,7 @@ STATICFILES_FINDERS = (
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '5*#74p#taescig^(kresv4sv6up(ui8unnh1eez4&s*l2mo$@4'
-ALTCHA_HMAC_KEY = '4d59aae3d1c05710be52c101a35283a9f9eb76fc6c1d799db48b810ade2586bf'
+ALTCHA_HMAC_KEY = '4d59aae3d1c05710be52c101a35283a9f9eb76fc6c1d799db48b810ade2586bf' # Replace this with your own 64 char hex string, this should be kept secret.
 
 
 TEMPLATES = [{

--- a/settings.py
+++ b/settings.py
@@ -61,6 +61,8 @@ STATICFILES_FINDERS = (
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '5*#74p#taescig^(kresv4sv6up(ui8unnh1eez4&s*l2mo$@4'
+ALTCHA_HMAC_KEY = '4d59aae3d1c05710be52c101a35283a9f9eb76fc6c1d799db48b810ade2586bf'
+
 
 TEMPLATES = [{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -102,7 +104,8 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'signup',
-    'django.contrib.admin'
+    'django.contrib.admin',
+    "django_altcha",
 )
 
 LOGGING = {

--- a/signup/forms.py
+++ b/signup/forms.py
@@ -2,12 +2,14 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from signup.models import SignupQueue
-
+from django_altcha import AltchaField
 
 class ApplyLicenseForm(forms.ModelForm):
 
     # tech_name = forms.CharField(label=_('Name'))
     # tech_email = forms.EmailField(label=_('Email'))
+
+    captcha = AltchaField()
 
     class Meta:
         model = SignupQueue

--- a/signup/templates/signup/signupqueue_form.html
+++ b/signup/templates/signup/signupqueue_form.html
@@ -10,11 +10,11 @@
                 <form class="form form-horizontal" method='post' action='{% url 'signup_apply' %}'>
                     {% for field in form %}
                         <div class="form-group {% if field.errors %}error{% endif %}">
-                            <label class="col-sm-2 control-label">{{ field.label }}</label>
+                            <label class="col-sm-2 control-label">{% if field.name != "captcha" %}{{ field.label }} {% endif %}</label>
                             <div class="col-sm-10">
                                 {{ field }}
                                 {% if field.errors %}<span class="help-inline">{{ field.errors|striptags }}</span>{% else %}
-                                    {% if field.field.required %}&nbsp;<span class="label label-important"><small>{% trans "required" %}</small></span>{% endif %}
+                                    {% if field.field.required and field.name != "captcha" %}&nbsp;<span class="label label-important"><small>{% trans "required" %}</small></span>{% endif %}
                                 {% endif %}
 
                             </div>


### PR DESCRIPTION
This PR implements Altcha for the signup page, it shows as a regular captcha that you need to click. Pure post requests to the endpoint without the altcha token also don't work and are blocked by altcha

![firefox_QcpxNIuPXV](https://github.com/user-attachments/assets/cebfe157-5d33-4b62-b48f-95724c4389a2)
<img width="418" height="146" alt="image" src="https://github.com/user-attachments/assets/130e9f0f-3d53-4374-b96c-896d7b37ad48" />
<img width="558" height="387" alt="firefox_jz1EY3yopK" src="https://github.com/user-attachments/assets/f589d039-399d-43f5-be19-92802db7d801" />
<img width="328" height="128" alt="firefox_rGgew4uO6u" src="https://github.com/user-attachments/assets/52fdde2c-c4c6-4457-b57b-67bab55adce4" />

